### PR TITLE
fix: typo in usage link

### DIFF
--- a/posts/pwa/remix-pwa-sw.mdx
+++ b/posts/pwa/remix-pwa-sw.mdx
@@ -21,7 +21,7 @@ Check out the [installation guide](/sw/installation) for more information.
 
 ## Usage
 
-Check out the [usage guide](/sw/basix-setup) for more information.
+Check out the [usage guide](/sw/basic-setup) for more information.
 
 ## API
 


### PR DESCRIPTION
This pull request updates the link in the _Usage_ section from https://remix-pwa-docs.vercel.app/pwa/remix-pwa-sw