### PR TITLE
fix typo of bu to by in vite config page

### DIFF
--- a/posts/main/utils/vite-config.mdx
+++ b/posts/main/utils/vite-config.mdx
@@ -7,7 +7,7 @@ alternateTitle: vite.config.ts
 import Warn from './warn.tsx'
 
 Remix PWA uses Vite to compile and bundle your service workers. The process isn't linear, so you are able to customize the
-process bu utilising the configuration options exposed by the `remixPWA` plugin.
+process by utilising the configuration options exposed by the `remixPWA` plugin.
 
 ## Remix PWA Vite Plugin Config
 


### PR DESCRIPTION
Noticed a typo when reading the docs.
Only small.